### PR TITLE
Disables char64s length calculation

### DIFF
--- a/_internal/Dependencies/libbase64++/libbase64++.h
+++ b/_internal/Dependencies/libbase64++/libbase64++.h
@@ -186,7 +186,7 @@ namespace libbase64 {
 			}
 			
 			//check to be sure there aren't odd characters or characters in the wrong places
-			size_t pos = encoded.find_first_not_of(libbase64_characters::getChar64<CHARTYPE>());
+			size_t pos = encoded.find_first_not_of(libbase64_characters::getChar64<CHARTYPE>(), 0, 64);
 			if (libbase64_unlikely(pos != STRINGTYPE::npos)){
 				LIBBASE64CODECOVERAGEBRANCH;
 				if (libbase64_unlikely(encoded[pos] != (CHARTYPE)'=')){


### PR DESCRIPTION
Passes explicitly all the arguments to the find_first_not_of that may help to overcome issue detected by AddressSanitizer:

```
 #0 __interceptor_strlen (/usr/lib/x86_64-linux-gnu/libasan.so.1+0x31ed7) 
 #1 std::string::find_first_not_of(char const*, unsigned long) const (/usr/lib/x86_64-linux-gnu/libstdc++.so.6+0xcba44) 
 #2 decode<std::basic_string<char>, char, unsigned char, true> ../libjson/_internal/Dependencies/libbase64++/libbase64++.h:193 
 #3 JSONBase64::json_decode64(std::string const&) ../libjson/_internal/Source/JSON_Base64.h:27 
 #4 decode64 ../libjson/include/libjson.h:199 

 0x... is located 0 bytes to the right of global variable 'char64s' from '...' (0x...) of size 64 
 SUMMARY: AddressSanitizer: global-buffer-overflow ??:0 __interceptor_strlen
```

Global buffer overflow happens because `std::string::find_first_not_of(const char*, size_t pos = 0)` requires valid (null-terminated) C-string passed as a first argument. Since `char64s` is not ended with `\0`. thus it is not valid C-string, trying to get its length via `strlen` function gives buffer overflow.

Synopsis: http://www.cplusplus.com/reference/string/string/find_first_not_of/
Implementation in libstdc++: https://gcc.gnu.org/onlinedocs/libstdc++/latest-doxygen/a00998_source.html#l02129
