### PR TITLE
facing date string error 20\/06\/2016, now resolved it 20/06/2016

### DIFF
--- a/_internal/Source/JSONWorker.cpp
+++ b/_internal/Source/JSONWorker.cpp
@@ -530,7 +530,7 @@ void JSONWorker::UnfixString(const json_string & value_t, bool flag, json_string
 				res += JSON_TEXT("\\r");
 				break;
 			 case JSON_TEXT('/'):	//forward slash
-				res += JSON_TEXT("\\/");
+				res += JSON_TEXT("/");
 				break;
 			 case JSON_TEXT('\b'):	//backspace
 				res += JSON_TEXT("\\b");


### PR DESCRIPTION
Hi Admin,

Please add this commit to existing tree. Please see below corrections for date string preparations.
Unnecessary "\/" literals were getting added to date strings those I have removed.
Now whoever is using this library, will NOT face this issue any more if you accept and merge this pull request.

Before changing JSON library code :
{
    "String Node" : "19\/06\/2016",
    "Integer Node" : 42,
    "Floating Point Node" : 3.14,
    "Boolean Node" : true
}

After changing JSON library code :

{
    "String Node" : "19/06/2016",
    "Integer Node" : 42,
    "Floating Point Node" : 3.14,
    "Boolean Node" : true
}

Thanks.
